### PR TITLE
Python 3.13 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 1.0.6
+-------------
+
+Released 2024-12-06
+
+-   Support for Python 3.13.
+-   End support for Python 3.7 and 3.8 and Matplotlib 3.0, 3.1, and 3.2.
+
 Version 1.0.5
 -------------
 

--- a/src/chromophile_dev/distributions/python/chromophile/__init__.py.jinja
+++ b/src/chromophile_dev/distributions/python/chromophile/__init__.py.jinja
@@ -95,16 +95,10 @@ def _expand_aliases(aliases):
 
 
 def _init_cmaps(index):
-    try:
-        # 3.9+
-        pkg_traversable = importlib.resources.files(__package__)
-    except AttributeError:
-        # 3.7, 3.8
-        data = importlib.resources.read_binary(__package__, '_cmaps.dat')
-    else:
-        cmaps_file = pkg_traversable / '_cmaps.dat'
-        with open(cmaps_file, 'rb') as fp:
-            data = fp.read()
+    pkg_traversable = importlib.resources.files(__package__)
+    cmaps_file = pkg_traversable / '_cmaps.dat'
+    with open(cmaps_file, 'rb') as fp:
+        data = fp.read()
 
     if len(data) % 3 != 0:
         raise ImportError(

--- a/src/chromophile_dev/distributions/python/pyproject.toml.jinja
+++ b/src/chromophile_dev/distributions/python/pyproject.toml.jinja
@@ -11,7 +11,7 @@ authors = [
 description = "Color maps for continuous quantitative data"
 readme = "README.rst"
 license = { file="LICENSE.txt" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Development Status :: 5 - Production/Stable",

--- a/src/chromophile_dev/distributions/python/tox.ini
+++ b/src/chromophile_dev/distributions/python/tox.ini
@@ -1,17 +1,13 @@
 [tox]
 isolated_build = True
 envlist =
-    py{37,38,39,310,311,312}-nompl
-    py{37,38,39,310,311}-{mpl30,mpl31,mpl32,mpl33,mpl34,mpl35}
-    py{38,39,310,311,312}-{mpl36,mpl37}
-    py{39,310,311,312}-{mpl38,mpl39}
+    py{39,310,311,312}-nompl
+    py{39,310,311}-{mpl33,mpl34,mpl35}
+    py{39,310,311,312}-{mpl36,mpl37,mpl38,mpl39}
 
 [testenv]
 deps =
     pytest
-    mpl30: matplotlib>=3.0,<3.1
-    mpl31: matplotlib>=3.1,<3.2
-    mpl32: matplotlib>=3.2,<3.3
     mpl33: matplotlib>=3.3,<3.4
     mpl34: matplotlib>=3.4,<3.5
     mpl35: matplotlib>=3.5,<3.6

--- a/src/chromophile_dev/distributions/python/tox.ini
+++ b/src/chromophile_dev/distributions/python/tox.ini
@@ -3,7 +3,7 @@ isolated_build = True
 envlist =
     py{39,310,311,312}-nompl
     py{39,310,311}-{mpl33,mpl34,mpl35}
-    py{39,310,311,312}-{mpl36,mpl37,mpl38,mpl39}
+    py{39,310,311,312,313}-{mpl36,mpl37,mpl38,mpl39}
 
 [testenv]
 deps =


### PR DESCRIPTION
Add Python 3.13 support. Drop support for Python 3.7 and 3.8 and for Matplotlib 3.0, 3.1, and 3.2.